### PR TITLE
Added word counting parameters to allow for special options (e.g. counting highlighted blocks only)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "@logseq/libs": "^0.0.14",
+    "type-flag": "^3.0.0",
     "words-count": "^2.0.2"
   },
   "logseq": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "license": "MIT",
   "dependencies": {
     "@logseq/libs": "^0.0.14",
-    "rxjs": "^7.8.0",
     "words-count": "^2.0.2"
   },
   "logseq": {

--- a/src/services/filters/highlighted.ts
+++ b/src/services/filters/highlighted.ts
@@ -1,0 +1,5 @@
+import { BlockEntity } from "@logseq/libs/dist/LSPlugin";
+
+export default function highlight(block: BlockEntity): boolean {
+  return block.properties != null && "backgroundColor" in block.properties;
+}

--- a/src/services/format.ts
+++ b/src/services/format.ts
@@ -1,0 +1,3 @@
+export function removeFormat(str: string) {
+  return str.replace(/\nbackground-color:: (\w+)/g, "");
+}

--- a/src/services/getCount.ts
+++ b/src/services/getCount.ts
@@ -1,5 +1,6 @@
 import { BlockEntity } from "@logseq/libs/dist/LSPlugin.user";
 import { mixedWordsFunction, simpleWordsFunction } from "./countWords";
+import { removeFormat } from "./format";
 
 export default function getCount(
   childrenArr: BlockEntity[],
@@ -9,10 +10,11 @@ export default function getCount(
   if (countWhat === "words") {
     function recurse(childrenArr: BlockEntity[]) {
       for (let a = 0; a < childrenArr.length; a++) {
+        const content = removeFormat(childrenArr[a].content);
         if (logseq.settings!.forceWordCount) {
-          totalCount += simpleWordsFunction(childrenArr[a].content);
+          totalCount += simpleWordsFunction(content);
         } else {
-          totalCount += mixedWordsFunction(childrenArr[a].content);
+          totalCount += mixedWordsFunction(content);
         }
         if (childrenArr[a].children) {
           recurse(childrenArr[a].children as BlockEntity[]);
@@ -25,7 +27,7 @@ export default function getCount(
   } else if (countWhat === "chars") {
     function recurse(childrenArr: BlockEntity[]) {
       for (let a = 0; a < childrenArr.length; a++) {
-        totalCount += childrenArr[a].content.length;
+        totalCount += removeFormat(childrenArr[a].content).length;
 
         if (childrenArr[a].children) {
           recurse(childrenArr[a].children as BlockEntity[]);

--- a/src/services/getCount.ts
+++ b/src/services/getCount.ts
@@ -1,14 +1,14 @@
 import { BlockEntity } from "@logseq/libs/dist/LSPlugin";
-import { Options, parseQuery } from "./query.ts";
 import { mixedWordsFunction, simpleWordsFunction } from "./countWords";
 import { removeFormat } from "./format.ts";
+import { Options, parseQuery } from "./query.ts";
 
 export interface CountResult { count: number; options: Options; }
 
-export default function getCount(
-  childrenArr: BlockEntity[],
+export default async function getCount(
+  parentBlock: BlockEntity,
   query: string = "",
-): CountResult {
+): Promise<CountResult> {
   const options = parseQuery(query);
 
   let totalCount = 0;
@@ -16,7 +16,7 @@ export default function getCount(
   function recurse(childrenArr: BlockEntity[]) {
     for (const child of childrenArr) {
       if (options.filters.every(filter => filter(child))) {
-        const content = removeFormat(child.content)
+        const content = removeFormat(child.content);
         if (options.countingType == "words") {
           if (logseq.settings!.forceWordCount) {
             totalCount += simpleWordsFunction(content);
@@ -32,6 +32,12 @@ export default function getCount(
       }
     }
   }
-  recurse(childrenArr);
+  if (options.countingContext == "block") {
+    recurse(parentBlock.children as BlockEntity[]);
+  } else {
+    const page = (await logseq.Editor.getPage(parentBlock.page.id))!;
+    const pageBlocksTree = await logseq.Editor.getPageBlocksTree(page.name);
+    recurse(pageBlocksTree);
+  }
   return { count: totalCount, options };
 }

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -1,9 +1,12 @@
 import { BlockEntity } from "@logseq/libs/dist/LSPlugin.user";
 import { typeFlag } from "type-flag";
 
+type Filter = ((block: BlockEntity) => boolean);
+
 export interface Options {
   countingType: "words" | "characters";
   target?: number;
+  filters: Filter[];
 }
 
 const optionsSchemas = {
@@ -16,8 +19,10 @@ export function parseQuery(query: string): Options {
   if (Object.entries(parsing.unknownFlags).length > 0) {
     throw new Error("invalid word counting query arguments")
   }
+  const filters: Filter[] = [];
   return {
     countingType: parsing.flags.characters ? "characters" : "words",
     target: parsing.flags.target,
+    filters
   };
 }

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -1,0 +1,23 @@
+import { BlockEntity } from "@logseq/libs/dist/LSPlugin.user";
+import { typeFlag } from "type-flag";
+
+export interface Options {
+  countingType: "words" | "characters";
+  target?: number;
+}
+
+const optionsSchemas = {
+  characters: Boolean,
+  target: Number,
+};
+
+export function parseQuery(query: string): Options {
+  const parsing = typeFlag(optionsSchemas, query.split(" "));
+  if (Object.entries(parsing.unknownFlags).length > 0) {
+    throw new Error("invalid word counting query arguments")
+  }
+  return {
+    countingType: parsing.flags.characters ? "characters" : "words",
+    target: parsing.flags.target,
+  };
+}

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -1,5 +1,6 @@
 import { BlockEntity } from "@logseq/libs/dist/LSPlugin.user";
 import { typeFlag } from "type-flag";
+import highlight from "./filters/highlighted.ts";
 
 type Filter = ((block: BlockEntity) => boolean);
 
@@ -12,6 +13,7 @@ export interface Options {
 const optionsSchemas = {
   characters: Boolean,
   target: Number,
+  "filter-highlight": Boolean,
 };
 
 export function parseQuery(query: string): Options {
@@ -20,6 +22,9 @@ export function parseQuery(query: string): Options {
     throw new Error("invalid word counting query arguments")
   }
   const filters: Filter[] = [];
+  if (parsing.flags["filter-highlight"]) {
+    filters.push(highlight);
+  }
   return {
     countingType: parsing.flags.characters ? "characters" : "words",
     target: parsing.flags.target,

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -6,6 +6,7 @@ type Filter = ((block: BlockEntity) => boolean);
 
 export interface Options {
   countingType: "words" | "characters";
+  countingContext: "block" | "page";
   target?: number;
   filters: Filter[];
 }
@@ -14,12 +15,13 @@ const optionsSchemas = {
   characters: Boolean,
   target: Number,
   "filter-highlight": Boolean,
+  page: Boolean
 };
 
 export function parseQuery(query: string): Options {
   const parsing = typeFlag(optionsSchemas, query.split(" "));
   if (Object.entries(parsing.unknownFlags).length > 0) {
-    throw new Error("invalid word counting query arguments")
+    throw new Error("invalid word counting query arguments");
   }
   const filters: Filter[] = [];
   if (parsing.flags["filter-highlight"]) {
@@ -27,7 +29,8 @@ export function parseQuery(query: string): Options {
   }
   return {
     countingType: parsing.flags.characters ? "characters" : "words",
+    countingContext: parsing.flags.page ? "page" : "block",
     target: parsing.flags.target,
-    filters
+    filters,
   };
 }

--- a/src/services/renderCount.ts
+++ b/src/services/renderCount.ts
@@ -1,9 +1,9 @@
+import { CountResult } from "./getCount.ts";
+
 export default function renderCount(
   slot: string,
   id: string,
-  type: string,
-  target: string | undefined,
-  totalCount: number
+  { count, options }: CountResult
 ) {
   function button() {
     const {
@@ -13,21 +13,20 @@ export default function renderCount(
       characterTargetStr,
     } = logseq.settings!;
 
-    if (target === undefined) {
-      if (type.startsWith(":wordcount_")) {
-        return `${wordCountStr} ${totalCount}`;
-      } else if (type.startsWith(":wordcountchar_")) {
-        return `${characterCountStr} ${totalCount}`;
-      } else if (type.startsWith(":wordcount-page_")) {
-        return `${wordCountStr} ${!totalCount ? 0 : totalCount}`;
+    if (!options.target) {
+      switch (options.countingType) {
+        case "words":
+          return `${wordCountStr} ${count}`;
+        case "characters":
+          return `${characterCountStr} ${count}`;
       }
     } else {
-      const percentage = ((totalCount / parseInt(target)) * 100).toFixed(1);
-
-      if (type.startsWith(":wordcount_")) {
-        return `${wordTargetStr} ${percentage}% (${totalCount}/${target})`;
-      } else if (type.startsWith(":wordcountchar_")) {
-        return `${characterTargetStr} ${percentage}% (${totalCount}/${target})`;
+      const percentage = ((count / options.target) * 100).toFixed(1);
+      switch (options.countingType) {
+        case "words":
+          return `${wordTargetStr} ${percentage}% (${count}/${options.target})`;
+        case "characters":
+          return `${characterTargetStr} ${percentage}% (${count}/${options.target})`;
       }
     }
   }

--- a/src/services/renderCount.ts
+++ b/src/services/renderCount.ts
@@ -38,4 +38,11 @@ export default function renderCount(
     template: `
           <span class="wordcount-btn" data-slot-id="${id}" data-wordcount-id="${id}">${button()}</span>`,
   });
+
+  if (options.countingContext == "page" && logseq.settings!.toolbar) {
+    logseq.App.registerUIItem("toolbar", {
+      key: "wordcount-page",
+      template: `<p class="wordcount-toolbar">${button()}</p>`,
+    });
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1543,6 +1543,11 @@ type-fest@^0.20.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
+type-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/type-flag/-/type-flag-3.0.0.tgz#2caef2f20f2c71e960fe1d3b6f57bae8c8246459"
+  integrity sha512-3YaYwMseXCAhBB14RXW5cRQfJQlEknS6i4C8fCfeUdS3ihG9EdccdR9kt3vP73ZdeTGmPb4bZtkDn5XMIn1DLA==
+
 update-browserslist-db@^1.0.10:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz#9a2a641ad2907ae7b3616506f4b977851db5b940"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1438,13 +1438,6 @@ resolve-from@^4.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
-rxjs@^7.8.0:
-  version "7.8.1"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.1.tgz#6f6f3d99ea8044291efd92e7c7fcf562c4057543"
-  integrity sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==
-  dependencies:
-    tslib "^2.1.0"
-
 safe-buffer@^5.0.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"


### PR DESCRIPTION
Hello,

I hope that this pull request is welcome even though I didn't create issues before making it.

I needed the function provided by this plugin so I was glad it was already made available by someone, however in my case, I wanted to count only words from blocks that are highlighted in Logseq. So I figured I could add it in a fork and I thought maybe it could be helpful to someone else, hence why I'm also doing a pull request.

Regarding the changes to the original code base, they are significant, though I tried to maintain the original structure as much as possible, but I ran into some incompatibilities with the way the plugin has been implemented in some aspects so I had to change them to be able to add the features I needed. However, the changes don't affect the way the plugin is used by simple users (through Logseq commands). The only issue is that the new system will not work with how the "renderer" blocks were structured before so old users will need to delete these blocks and recreate them with the same commands as before. I understand it may be a big issue so I let the author of this project decide whether it's worth it.

Anyway, I made this changes for myself originally but maybe they can be useful to someone so here they are.

If you have any questions regarding the way I implemented things or if you want to review and/or improve my code, let me know.

Have a good day!