### PR TITLE
Set target percentage precision to one digit

### DIFF
--- a/src/services/create-wordcharcount-text.ts
+++ b/src/services/create-wordcharcount-text.ts
@@ -22,7 +22,7 @@ export const createWordcountText = (
   } else {
     // Session text
     const sessionTarget = parseInt(target)
-    const percentage = (totalCount / sessionTarget) * 100
+    const percentage = ((totalCount / sessionTarget) * 100).toFixed(1)
 
     switch (true) {
       case type.startsWith(':wordcount_'):


### PR DESCRIPTION
Set the target percentage precision to one digit for readability.

<img width="300" alt="Wordcount" src="https://github.com/user-attachments/assets/cef76490-34ff-40fa-ab68-4ca3e1c32bb9" />
